### PR TITLE
Create visitor explicitly instead of using new_site_visitor option

### DIFF
--- a/.sample-env
+++ b/.sample-env
@@ -12,6 +12,6 @@ SERVER=
 TOKEN=
 INCOMING_URL=
 SITE_ID=
+APPLICATION_TOKEN=
 
 # note: .env is a shell file so there can't be spaces around '=
-


### PR DESCRIPTION
`new_site_visitor` option is being removed. Now integrators can create
visitors themselves.